### PR TITLE
Filter Button display set to inline-flex

### DIFF
--- a/filter/FilterButton.jsx
+++ b/filter/FilterButton.jsx
@@ -147,7 +147,7 @@ function FilterLabel({label, selectedText, shyLabel}: FilterLabelProps) {
 
 const styles = StyleSheet.create({
   container: {
-    display: "flex",
+    display: "inline-flex",
     flexDirection: "row",
     alignItems: "center",
     background: latitudeColors.white,


### PR DESCRIPTION
This PR changes Filter Button's display to `inline-flex`. If Filters are used in a non-flex container, this Filter will take up the entire width.

## Sandbox:
https://core-18.sandbox2.eng-dev.flexport.com


## Before:
![image](https://user-images.githubusercontent.com/5897853/68427913-ebee3800-015f-11ea-9e58-9ebe04669ce2.png)


## After:
![image](https://user-images.githubusercontent.com/5897853/68427873-d2e58700-015f-11ea-96aa-b463827af421.png)

## Unchanged in product:
![image](https://user-images.githubusercontent.com/5897853/68432698-cfef9400-0169-11ea-9555-ea3942c05bbc.png)


## Manual Test Plan:
Test out filters in the following places:
* https://www-18.sandbox2.eng-dev.flexport.com/design/components/SelectFilter
* https://core-18.sandbox2.eng-dev.flexport.com
