### PR TITLE
Fixed wrong GitHub link

### DIFF
--- a/design_system/interfaces/Resources.jsx
+++ b/design_system/interfaces/Resources.jsx
@@ -72,7 +72,7 @@ export default function Resources() {
                   <AnchorButton
                     intent="basic"
                     kind="hollow"
-                    href="https://github.com/flexport/design"
+                    href="https://github.com/flexport/latitude"
                     openInNewTab={true}
                     label="Browse the repo"
                   />


### PR DESCRIPTION
Corrected the wrong link to the GitHub repository in https://www.flexport.com/design/resources