### PR TITLE
Move column customization after the table so z-index is not required

### DIFF
--- a/table/Table.jsx
+++ b/table/Table.jsx
@@ -726,19 +726,6 @@ export default function Table<T>({
   return (
     <div className={css(styles.table)}>
       <StickyScrollContext.Provider value={StickyScrollPolyfill.context}>
-        {columnCustomizationEnabled ? (
-          <ColumnCustomization
-            columnDefinitions={customizableColumns}
-            visibleColumnIds={visibleColumnDefinitions.map(cd => cd.id)}
-            onVisibleColumnIdsChange={visibleColumnIds => {
-              onHiddenColumnsChange(
-                customizableColumns
-                  .filter(cd => !visibleColumnIds.includes(cd.id))
-                  .map(cd => ({columnId: cd.id}))
-              );
-            }}
-          />
-        ) : null}
         <AutoSizer>
           {({width, height}: {|+width: number, +height: number|}) => (
             <InfiniteLoader
@@ -768,6 +755,19 @@ export default function Table<T>({
             </InfiniteLoader>
           )}
         </AutoSizer>
+        {columnCustomizationEnabled ? (
+          <ColumnCustomization
+            columnDefinitions={customizableColumns}
+            visibleColumnIds={visibleColumnDefinitions.map(cd => cd.id)}
+            onVisibleColumnIdsChange={visibleColumnIds => {
+              onHiddenColumnsChange(
+                customizableColumns
+                  .filter(cd => !visibleColumnIds.includes(cd.id))
+                  .map(cd => ({columnId: cd.id}))
+              );
+            }}
+          />
+        ) : null}
       </StickyScrollContext.Provider>
     </div>
   );
@@ -1222,7 +1222,6 @@ const styles = StyleSheet.create({
     display: "flex",
     alignItems: "center",
     right: 0,
-    zIndex: 3,
     borderTop: `1px solid ${colors.grey30}`,
     borderBottom: `1px solid ${colors.grey30}`,
     borderLeft: `1px solid ${colors.grey30}`,


### PR DESCRIPTION
This moves the column customization component after the table to take advantage of the natural dom hierarchy so z-index is not required. Currently, the z-index of the button causes it to sit on top of a sidebar that pops out in transmission

![image](https://user-images.githubusercontent.com/4034511/68713748-64376d80-0553-11ea-8d82-fd93f97dc29a.png)
