### PR TITLE
Revert "update contributing doc with better workflow"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,28 +24,25 @@ You don't need to wait for a Latitude PR to be merged before beginning your
 product work. It's easy to work on your Latitude and product changes
 concurrently.
 
-We will use the following tools to help sync the local repos:
+To set this up, point your monorepo's latitude dependency to your branch:
 
 ```bash
-brew install bindfs
-brew cask install osxfuse
+cd ~/monorepo
+
+# point to your latitude feature branch
+yarn upgrade latitude@https://github.com/flexport/latitude.git#feature-branch-name
 ```
 
-To set this up, point your monorepo's latitude dependency to your local repo:
+After pushing updates to your latitude branch, run `yarn upgrade latitude` from
+your monorepo to see your changes there. Feel free to push as many times as you
+like. Remember, you can squash changes before opening a PR or requesting review.
+
+Once your Latitude PR merges, point your branch at master again by running
 
 ```bash
-bindfs -r <full_path_to_latitude_repo> <full_path_to_monorepo>/node_modules/latitude
-# the first time you run this, you will have to go into Mac System Preferences to enable its kernel extension
+yarn upgrade latitude@https://github.com/flexport/latitude.git#master
 ```
 
-To go back to the original version of latitude:
-
-```bash
-umount <full_path_to_monorepo>/node_modules/latitude
-# NOTE: if you try running yarn install before going back to the original version of latitude, it will fail!
-```
-
-It is recommended you set up aliases for the above commands if you want to follow this flow
 
 ## Workflow tip: watch mode
 


### PR DESCRIPTION
Reverts flexport/latitude#92

We noticed monorepo webpack builds do not work correctly with this setup (checked `CoreApp`, `DesignSystemApp`, `DispatchApp`, `ClientApp`). @jxu-flexport, are additional setup steps?