### PR TITLE
Enable forced appearance of aggreagate row

### DIFF
--- a/stories/table/Table.stories.jsx
+++ b/stories/table/Table.stories.jsx
@@ -220,6 +220,35 @@ const PinnedColumnsHoist = () => {
   return <div className={css(styles.container)}>{table}</div>;
 };
 
+const PinnedAggregateRowHoist = () => {
+  const [expandedRows, setExpandedRows] = React.useState(new Set());
+  const [selectedRows, setSelectedRows] = React.useState(new Set());
+
+  const [sortBy, setSortBy] = React.useState({
+    columnId: "id",
+    direction: "asc",
+  });
+
+  const table = (
+    <Table
+      data={data.slice(0, 100)}
+      columnDefinitions={columnDefinitions}
+      getUniqueRowId={row => row.id}
+      rowSelectionEnabled={true}
+      selectedRows={selectedRows}
+      onSelectedRowsChange={setSelectedRows}
+      rowAggregationEnabled={true}
+      rowAggregationRowPinned={true}
+      getRowGroupId={row => row.network}
+      expandedRows={expandedRows}
+      onExpandedRowsChange={setExpandedRows}
+      sortBy={sortBy}
+      onSortByChange={setSortBy}
+    />
+  );
+  return <div className={css(styles.container)}>{table}</div>;
+};
+
 const InfiniteLoadHoist = () => {
   const [sortBy, setSortBy] = React.useState({
     columnId: "id",
@@ -341,6 +370,7 @@ stories.add("Row Aggregation Table", () => <RowAggregationHoist />);
 stories.add("Row Aggregation Selection Table", () => (
   <RowAggregationSelectionHoist />
 ));
+stories.add("Row Aggregation Pinned Row", () => <PinnedAggregateRowHoist />);
 stories.add("Pinned Columns Table", () => <PinnedColumnsHoist />);
 stories.add("Infinite Load Table", () => <InfiniteLoadHoist />);
 stories.add("Rerender Table Test", () => <RerenderTableTest />);

--- a/table/Table.jsx
+++ b/table/Table.jsx
@@ -201,6 +201,7 @@ export default function Table<T>({
   onSortByChange = noop,
   rowAggregationEnabled = false,
   rowAggregationPinned = true,
+  rowAggregationRowPinned = false,
   getRowGroupId,
   expandedRows = new Set(),
   onExpandedRowsChange = noop,
@@ -249,6 +250,8 @@ export default function Table<T>({
   +rowAggregationEnabled?: boolean,
   /** Whether or not the arrows for row aggregation will be pinned to the left of the table */
   +rowAggregationPinned?: boolean,
+  /** Whether or not to display aggregate row, even when only a single entry is in group */
+  +rowAggregationRowPinned?: boolean,
   /** A function to determine which row group the row belongs to, this ID is what is returned in the row expansions set  */
   +getRowGroupId?: T => string,
   /** Which row groups are expanded, based on IDs returned from getRowGroupId */
@@ -379,7 +382,7 @@ export default function Table<T>({
     return rowGroups.reduce(
       (rows, rowGroup) => [
         ...rows,
-        rowGroup.length > 1
+        rowAggregationRowPinned || rowGroup.length > 1
           ? flattenRowGroup(rowGroup)
           : flattenRow(rowGroup[0]),
         ...(expandedRows.has(getRowGroupId(rowGroup[0]))


### PR DESCRIPTION
The current implementation of aggregate rows in tables only displayes
thew aggregate row if the group has more than one entry. In the instance
of users displaying tested data using row groups displaying the
aggregate row even for a group of 1 could be useful. This adds an
optional flag that forces the appearance of this row for all groups,
even those of size 1.
