### PR TITLE
IconButton padding will always make icon only buttons square

### DIFF
--- a/Banner.jsx
+++ b/Banner.jsx
@@ -86,7 +86,6 @@ export default function Banner({
     closeNode = (
       <div
         className={css(
-          styles.closeWrapper,
           intent === "danger" && styles.closeWrapperDanger
         )}
       >
@@ -97,6 +96,7 @@ export default function Banner({
           intent="none"
           type="button"
           size="l"
+          height={{type: "customDontUse", height: 20}}
         />
       </div>
     );
@@ -151,10 +151,6 @@ const styles = StyleSheet.create({
   },
   iconWrapper: {
     marginRight: "20px",
-  },
-  closeWrapper: {
-    width: "20px",
-    height: "20px",
   },
   closeWrapperDanger: {
     ":nth-child(1n) > button > span > svg": {

--- a/button/IconButton.jsx
+++ b/button/IconButton.jsx
@@ -16,6 +16,8 @@ import stringOrFalse from "../tools/stringOrFalse";
 import {sharedStyles, getButtonStyle} from "../button/styles";
 import ThemeNameContext from "../context/ThemeNameContext";
 import type {ButtonSize} from "./Button";
+import sizes from "../sizes";
+import iconSizes from "../iconSizes";
 
 type IconButtonKind = "hollow" | "bare" | "blank";
 export type IconButtonIntent = "basic" | "none" | "danger";
@@ -189,12 +191,14 @@ export default class IconButton extends React.PureComponent<Props, State> {
         ? [IconComponent, LabelComponent]
         : [LabelComponent, IconComponent];
 
+    const styles = getStyles(size, height);
+
     return (
       <button
         className={css(
           ...buttonStyles.button,
+          styles.button,
           intent === "none" ? styles.none : null,
-          styles[size]
         )}
         onClick={onClick}
         onMouseDown={onMouseDown}
@@ -203,9 +207,6 @@ export default class IconButton extends React.PureComponent<Props, State> {
         onBlur={this.handleBlur}
         type={type}
         disabled={disabled || isLoading || wasLoading}
-        style={{
-          height: height.type === "customDontUse" ? height.height : undefined,
-        }}
       >
         {isLoading && (
           <div className={css(sharedStyles.loaderContainer)}>
@@ -228,7 +229,7 @@ export default class IconButton extends React.PureComponent<Props, State> {
   }
 }
 
-const getIconSize = (size: "s" | "m" | "l") => {
+const getIconSize = (size: ButtonSize) => {
   switch (size) {
     case "s":
       return "xxs";
@@ -248,25 +249,31 @@ const getLoaderSize = (buttonSize: ButtonSize): number => {
   return 24;
 };
 
-const styles = StyleSheet.create({
+/** Padding makes icon-only IconButtons perfect squares */
+const getButtonPadding = (
+  size: ButtonSize,
+  height: {type: "fixed"} | {type: "customDontUse", height: number},
+) => {
+  const buttonHeight = height.type === "fixed" ? sizes[size] : height.height;
+  const iconHeight = iconSizes[getIconSize(size)];
+  const borderWidth = 2;
+  const horizontalPadding = (buttonHeight - iconHeight) / 2 + borderWidth;
+
+  return `0 ${horizontalPadding}px`;
+}
+
+const getStyles = (
+  size: ButtonSize,
+  height: {type: "fixed"} | {type: "customDontUse", height: number},
+) => StyleSheet.create({
+  button: {
+    padding: getButtonPadding(size, height),
+    height: height.type === "customDontUse" ? height.height : undefined,
+  },
   none: {
     fill: colors.grey50,
     ":hover span svg": {
       fill: colors.black,
     },
-  },
-  /*
-    Padding differences for IconButton to make icon-only IconButtons perfect
-    squares. deprecatedWhitespace.js and whitespace.js do not support this
-    specific use case.
-  */
-  s: {
-    padding: "0 6.5px",
-  },
-  m: {
-    padding: "0 9px",
-  },
-  l: {
-    padding: "0 12px",
   },
 });


### PR DESCRIPTION
## Description
This PR updates the way IconButton computes its padding -- before, IconButton's padding was based off of the Button's size such that the button's padding would make an icon only button square. This PR computes the padding based off the button's height.