### PR TITLE
Manually calculate/specify height of Logo SVG

### DIFF
--- a/Logo.jsx
+++ b/Logo.jsx
@@ -72,7 +72,7 @@ function Logo({colorScheme, width}: Props) {
       viewBox={viewBox}
       width={w}
       height={h}
-      style={{width: width ? `${width}px` : "100%", height: "auto"}}
+      style={{width: width ? `${width}px` : "100%", height: `${width * h / w}px`}}
       role="img"
       aria-hidden="true"
       aria-labelledby="title desc"


### PR DESCRIPTION
## Description:
The Flexport logo in the workspace nav bar is an SVG. By default, when you set the height of an SVG to auto, Internet Explorer 11 sets its height to `150px`, a global default. This causes the height of the entire `WorkspacesNav` to become 150px, even though its actual height is only 64px. This means that users cannot interact with the top ~90 px of content on the screen.

![image](https://user-images.githubusercontent.com/49162946/72375897-8fb11280-36d2-11ea-85a6-62e06acdc5eb.png)
_Users trying to interact with the filter bar can only click on the small part of the filter buttons that do not overlap the highlighted blue region.~

## Jira:
https://go/j/WH-303

## Manual Testing Plan:
Go to the warehouse app in Internet Explorer.
Interact with the filter bar. You should be able to click anywhere on the buttons.

## Screenshots:
_Now they can interact with the entire filter bar_
![image](https://user-images.githubusercontent.com/49162946/72376205-31d0fa80-36d3-11ea-81c5-9c054cbb3590.png)
